### PR TITLE
Allow deployment of the executable through maven repos.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.skife.maven</groupId>
     <artifactId>really-executable-jar-maven-plugin</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>Really Executable Jar Maven Plugin</name>

--- a/src/main/java/org/skife/waffles/MyMojo.java
+++ b/src/main/java/org/skife/waffles/MyMojo.java
@@ -4,6 +4,7 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
 import org.apache.maven.project.artifact.AttachedArtifact;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
@@ -34,6 +35,13 @@ public class MyMojo extends AbstractMojo
     private MavenProject project;
 
     /**
+     * @component
+     * @required
+     * @readonly
+     */
+    private MavenProjectHelper projectHelper;
+
+    /**
      * The greeting to display.
      *
      * @parameter
@@ -53,6 +61,20 @@ public class MyMojo extends AbstractMojo
      * @parameter
      */
     private String classifier;
+
+    /**
+     * Attach the binary as an artifact to the deploy.
+     *
+     * @parameter
+     */
+    private boolean attachProgramFile = false;
+
+    /**
+     * File ending of the program artifact.
+     *
+     * @parameter
+     */
+    private String programFileType = "sh";
 
     /**
      *
@@ -87,6 +109,9 @@ public class MyMojo extends AbstractMojo
                     File exec = new File(dir, programFile);
                     FileUtils.copyFile(file, exec);
                     makeExecutable(exec);
+                    if (attachProgramFile) {
+                        projectHelper.attachArtifact(project, programFileType, exec);
+                    }
                 }
             } else {
                 for (File file : files) {


### PR DESCRIPTION
Adds two new options:

<attachProgramFile>true|false</attachProgramFile>

if true, adds the created executable as a build artifact.

Due to the way maven handles artifacts, it will be named
${artifactId}-${version}.<program file type>. The program file type
can be set with

<programFileType>exe</programFileType> and defaults to "sh".

It is not possible to install or deploy and artifact without an ending
("type" in maven speak).
