### PR TITLE
Fix IOException to not be swallowed inside MojoExecutionException

### DIFF
--- a/src/main/java/org/skife/waffles/MyMojo.java
+++ b/src/main/java/org/skife/waffles/MyMojo.java
@@ -138,7 +138,7 @@ public class MyMojo extends AbstractMojo
 
         }
         catch (IOException e) {
-            throw new MojoExecutionException(e, "FAILURE!", e.getMessage());
+            throw new MojoExecutionException(e.getMessage(), e);
         }
 
     }


### PR DESCRIPTION
Previously, we invoked
`MojoExecutionException( Object source, String shortMessage, String longMessage )`
which takes no 'cause', so instead let's use
`MojoExecutionException( String message, Exception cause )`