### PR TITLE
Lots of cleanup of IO operations, add Windows support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.basepom</groupId>
         <artifactId>basepom-standard-oss</artifactId>
-        <version>4</version>
+        <version>9</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,8 @@
   </scm>
 
     <properties>
-        <project.jdk6.home>${env.JAVA6_HOME}</project.jdk6.home>
-        <project.build.targetJdk>1.6</project.build.targetJdk>
+        <project.jdk7.home>${env.JAVA7_HOME}</project.jdk7.home>
+        <project.build.targetJdk>1.7</project.build.targetJdk>
         <dep.maven.version>2.0.6</dep.maven.version>
 
         <dep.plugin.release.version>2.5</dep.plugin.release.version>
@@ -134,13 +134,13 @@
                 </property>
             </activation>
             <properties>
-                <project.jdk6.home>${env.JAVA_HOME}</project.jdk6.home>
+                <project.jdk7.home>${env.JAVA_HOME}</project.jdk7.home>
             </properties>
         </profile>
         <profile>
             <id>cross-compile</id>
             <activation>
-                 <jdk>(1.6,]</jdk>
+                 <jdk>(1.7,]</jdk>
             </activation>
             <build>
                 <pluginManagement>
@@ -149,14 +149,14 @@
                             <artifactId>maven-compiler-plugin</artifactId>
                             <configuration>
                                 <compilerArguments children.combine="append">
-                                    <bootclasspath>${project.jdk6.home}/jre/lib/rt.jar:${project.jdk6.home}/jre/lib/jce.jar:${project.jdk6.home}/../classes/classes.jar</bootclasspath>
+                                    <bootclasspath>${project.jdk7.home}/jre/lib/rt.jar:${project.jdk7.home}/jre/lib/jce.jar:${project.jdk7.home}/../classes/classes.jar</bootclasspath>
                                 </compilerArguments>
                             </configuration>
                         </plugin>
                         <plugin>
                             <artifactId>maven-javadoc-plugin</artifactId>
                             <configuration>
-                                <bootclasspath>${project.jdk6.home}/jre/lib/rt.jar:${project.jdk6.home}/jre/lib/jce.jar:${project.jdk6.home}/../classes/classes.jar</bootclasspath>
+                                <bootclasspath>${project.jdk7.home}/jre/lib/rt.jar:${project.jdk7.home}/jre/lib/jce.jar:${project.jdk7.home}/../classes/classes.jar</bootclasspath>
                             </configuration>
                         </plugin>
                     </plugins>

--- a/src/main/java/org/skife/waffles/MyMojo.java
+++ b/src/main/java/org/skife/waffles/MyMojo.java
@@ -184,7 +184,8 @@ public class MyMojo extends AbstractMojo
                 }
                 IOUtil.copy(in, out);
                 out.flush();
-                Runtime.getRuntime().exec("chmod +x " + file.getAbsolutePath());
+
+                file.setExecutable(true, false);
             }
             finally {
                 IOException x = null;

--- a/src/main/java/org/skife/waffles/ReallyExecutableJarMojo.java
+++ b/src/main/java/org/skife/waffles/ReallyExecutableJarMojo.java
@@ -41,7 +41,7 @@ import java.util.List;
  *
  * @goal really-executable-jar
  */
-public class MyMojo extends AbstractMojo
+public class ReallyExecutableJarMojo extends AbstractMojo
 {
     /**
      * The Maven project.

--- a/src/main/java/org/skife/waffles/ReallyExecutableJarMojo.java
+++ b/src/main/java/org/skife/waffles/ReallyExecutableJarMojo.java
@@ -189,5 +189,7 @@ public class ReallyExecutableJarMojo extends AbstractMojo
         }
 
         file.setExecutable(true, false);
+
+        getLog().info(String.format("Successfully made JAR [%s] executable", file.getAbsolutePath()));
     }
 }


### PR DESCRIPTION
Move forward to JDK7, leaving anyone with JDK6 to drown in the sands of history.  Lots of cleanup of resource handling, fix a leak of ClassLoader object, add Windows support (fixes #6)

Needs a bit more cleanup before merge, and probably a basepom 9 release.