### PR TITLE
Load scriptFile from filesystem first

### DIFF
--- a/src/main/java/org/skife/waffles/ReallyExecutableJarMojo.java
+++ b/src/main/java/org/skife/waffles/ReallyExecutableJarMojo.java
@@ -164,7 +164,7 @@ public class ReallyExecutableJarMojo extends AbstractMojo
             if (scriptFile == null) {
                 out.write(("#!/bin/sh\n\nexec java " + flags + " -jar \"$0\" \"$@\"\n\n").getBytes("ASCII"));
             }
-            else if (Files.exists(Paths.get((scriptFile)))) {
+            else if (Files.exists(Paths.get(scriptFile))) {
                 getLog().debug(String.format("Loading file[%s] from filesystem", scriptFile));
 
                 byte[] script = Files.readAllBytes(Paths.get(scriptFile));

--- a/src/main/java/org/skife/waffles/ReallyExecutableJarMojo.java
+++ b/src/main/java/org/skife/waffles/ReallyExecutableJarMojo.java
@@ -163,7 +163,15 @@ public class ReallyExecutableJarMojo extends AbstractMojo
 
             if (scriptFile == null) {
                 out.write(("#!/bin/sh\n\nexec java " + flags + " -jar \"$0\" \"$@\"\n\n").getBytes("ASCII"));
-            } else {
+            }
+            else if (Files.exists(Paths.get((scriptFile)))) {
+                getLog().debug(String.format("Loading file[%s] from filesystem", scriptFile));
+
+                byte[] script = Files.readAllBytes(Paths.get(scriptFile));
+                out.write(script);
+                out.write(new byte[]{'\n', '\n'});
+            }
+            else {
                 getLog().debug(String.format("Loading file[%s] from jar[%s]", scriptFile, original));
 
                 try (final URLClassLoader loader = new URLClassLoader(new URL[]{original.toUri().toURL()}, null);


### PR DESCRIPTION
If scriptFile is available on the filesystem load from there. If not, fall back to loading from the jar. This restores the original, and intended behavior of the plugin. Fixes #12 