### PR TITLE
added optional support for other packaging formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ To use it, add a plugin to your pom like
     <!-- (optional) name for binary executable, if not set will just -->
     <!-- make the regular jar artifact executable -->
     <programFile>nifty-executable</programFile>
+
+    <!-- (optional) support other packaging formats than jar -->
+    <!-- <allowOtherTypes>true</allowOtherTypes> -->
     
     <!-- (optional) name for a file that will define what script gets -->
     <!-- embedded into the executable jar.  This can be used to -->

--- a/src/main/java/org/skife/waffles/ReallyExecutableJarMojo.java
+++ b/src/main/java/org/skife/waffles/ReallyExecutableJarMojo.java
@@ -77,6 +77,12 @@ public class ReallyExecutableJarMojo extends AbstractMojo
     private String classifier;
 
     /**
+     * Allow other packaging types than "jar".
+     */
+    @Parameter(property = "really-executable-jar.allowOtherTypes")
+    private String allowOtherTypes;
+
+    /**
      * Attach the binary as an artifact to the deploy.
      */
     @Parameter(defaultValue="false", property = "really-executable-jar.attachProgramFile")
@@ -144,7 +150,7 @@ public class ReallyExecutableJarMojo extends AbstractMojo
             return false;
         }
 
-        if (!artifact.getType().equals("jar")) {
+        if (!Boolean.valueOf(allowOtherTypes) && !artifact.getType().equals("jar")) {
             return false;
         }
 


### PR DESCRIPTION
When creating a self contained war-file (including a jetty web server) I also want to make this really self executable.

I've added optional support via configuration.