### PR TITLE
use plexus-utils instead of commons-io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,12 +65,12 @@
         <dependency>
             <groupId>net.e175.klaus</groupId>
             <artifactId>zip-prefixer</artifactId>
-            <version>0.2.2</version>
+            <version>0.3.1</version>
         </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.11.0</version>
+        <dependency> <!-- should become redundant with Java 11 -->
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>3.5.1</version>
         </dependency>
 
         <dependency>

--- a/src/it/011-programFileAttached/pom.xml
+++ b/src/it/011-programFileAttached/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.skife.maven</groupId>
+        <artifactId>test-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>test-011</artifactId>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <programFile>bananas</programFile>
+                    <attachProgramFile>true</attachProgramFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>really-executable-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/it/011-programFileAttached/src/main/java/App.java
+++ b/src/it/011-programFileAttached/src/main/java/App.java
@@ -1,0 +1,7 @@
+public class App {
+    public static void main(String[] args) {
+        System.out.printf("%s %s!%n",
+                System.getProperty("testapp.greeting", "Hello"),
+                args.length > 0 ? args[0] : "world");
+    }
+}

--- a/src/it/011-programFileAttached/verify.groovy
+++ b/src/it/011-programFileAttached/verify.groovy
@@ -1,0 +1,15 @@
+import java.nio.file.Files
+
+File bananaJar = new File(new File(basedir, "target"), 'bananas')
+assert bananaJar.exists()
+result = bananaJar.toString().execute().text
+assert result.contains("Hello world!")
+
+File installedPlainJar = new File(localRepositoryPath, "org/skife/maven/test-011/1.0-SNAPSHOT/test-011-1.0-SNAPSHOT.jar")
+assert installedPlainJar.exists()
+
+// seems that Maven will forcibly rename the attached artifact. this monkey gets no banana.
+File installedBanana = new File(localRepositoryPath, "org/skife/maven/test-011/1.0-SNAPSHOT/test-011-1.0-SNAPSHOT.sh")
+assert installedBanana.exists()
+
+assert Files.size(bananaJar.toPath()) == Files.size(installedBanana.toPath())

--- a/src/main/java/org/skife/waffles/ReallyExecutableJarMojo.java
+++ b/src/main/java/org/skife/waffles/ReallyExecutableJarMojo.java
@@ -14,7 +14,6 @@
 package org.skife.waffles;
 
 import net.e175.klaus.zip.ZipPrefixer;
-import org.apache.commons.io.IOUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -24,6 +23,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.IOUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -35,6 +35,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static java.lang.String.format;
@@ -178,7 +179,8 @@ public class ReallyExecutableJarMojo extends AbstractMojo {
 
         Path target = file.toPath();
         try {
-            ZipPrefixer.applyPrefixesToZip(target, getPreamble(target.toUri()), "\n\n".getBytes(UTF_8));
+            ZipPrefixer.applyPrefixBytesToZip(target,
+                    Arrays.asList(getPreamble(target.toUri()), "\n\n".getBytes(UTF_8)));
         } catch (IOException e) {
             throw new MojoExecutionException(format("Failed to apply prefix to JAR [%s]", file.getAbsolutePath()), e);
         }
@@ -204,11 +206,10 @@ public class ReallyExecutableJarMojo extends AbstractMojo {
                 if (scriptIn == null) {
                     throw new IOException("unable to load " + scriptFile);
                 }
-                return IOUtils.toByteArray(scriptIn); // Java 9+: scriptIn.readAllBytes();
+                return IOUtil.toByteArray(scriptIn); // Java 9+: scriptIn.readAllBytes();
             }
         } catch (IOException e) {
             throw new MojoExecutionException("unable to load preamble data", e);
         }
     }
-
 }


### PR DESCRIPTION
Following the brief exchange with @hgschmie in #29 this is going back to plexus-utils instead of commons-io. I had slight PTSD from earlier Maven (2?) plugin projects where random versions of plexus-utils showed up on the classpath, but it seems that this is safe to do now.

Also bumps the zip-prefixer version and adds another integration test for dessert.
