### PR TITLE
Replace existing files when generating executable

### DIFF
--- a/src/main/java/org/skife/waffles/ReallyExecutableJarMojo.java
+++ b/src/main/java/org/skife/waffles/ReallyExecutableJarMojo.java
@@ -34,6 +34,7 @@ import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -143,7 +144,7 @@ public class ReallyExecutableJarMojo extends AbstractMojo {
                 File file = files.get(0);
                 File dir = file.getParentFile();
                 File exec = new File(dir, programFile);
-                Files.copy(file.toPath(), exec.toPath());
+                Files.copy(file.toPath(), exec.toPath(), StandardCopyOption.REPLACE_EXISTING);
                 makeExecutable(exec);
                 if (attachProgramFile) {
                     projectHelper.attachArtifact(project, programFileType, exec);


### PR DESCRIPTION
Should overwrite existing files so that doing `mvn package` twice in a row works (especially from within an IDE). Without it, I have to put an extra step in to delete the file (eg, with the maven-clean-plugin) and that's just a lot of code for something where a simple correct flag would work.