### PR TITLE
Corrected project URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <name>Really Executable Jar Maven Plugin</name>
     <description>Make jar files *really* executable.</description>
 
-    <url>https://github.com/brianm/really-executable-jar-maven-plugin</url>
+    <url>https://github.com/brianm/really-executable-jars-maven-plugin</url>
 
     <licenses>
         <license>


### PR DESCRIPTION
Hi!

Dependabot recently [prompted me to upgrade my usage of the plugin](https://github.com/Mastercard/flow/pull/285), but the links in that PR to the project were 404.
It looks like dependabot uses the pom's `url` element for that link.

Cheers!